### PR TITLE
fix mem overlap and hang

### DIFF
--- a/src/libinfinistore.cpp
+++ b/src/libinfinistore.cpp
@@ -227,6 +227,12 @@ int modify_qp_to_init(struct ibv_qp *qp) {
 int sync_rdma(connection_t *conn) {
     std::unique_lock<std::mutex> lock(conn->mutex);
     conn->cv.wait(lock, [&conn] { return conn->rdma_inflight_count == 0; });
+    if (conn->limited_bar1 == false) {
+        for (auto it = conn->local_mr.begin(); it != conn->local_mr.end(); it++) {
+            it->second->release();
+        }
+        conn->local_mr.clear();
+    }
     return 0;
 }
 


### PR DESCRIPTION
We conducted pressure testing using a testing tool and occasionally observed the system hanging. 
Meanwhile, upon analyzing the current logic, we believe that there may be issues with reusing previously existing bar1 mem. Under heavy request loads during pressure testing, due to the asynchronous nature of sync, confusion in the usage of bar1 mem might occur. Therefore, while one connection is performing sync, we should reorganize the mem map.

After the changes were made, the previous issues have not occurred for the time being.