### PR TITLE
update min alloc size to 16k

### DIFF
--- a/infinistore/lib.py
+++ b/infinistore/lib.py
@@ -85,8 +85,8 @@ class ServerConfig(_infinistore.ServerConfig):
             raise Exception("ib port of device should be greater than 0")
         if self.link_type not in ["IB", "Ethernet"]:
             raise Exception("link type should be IB or Ethernet")
-        if self.minimal_allocate_size < 64:
-            raise Exception("minimal allocate size should be greater than 64")
+        if self.minimal_allocate_size < 16:
+            raise Exception("minimal allocate size should be greater than 16")
 
 
 class Logger:


### PR DESCRIPTION
The min-allocator-size was set to 64k, as we think the minimal page size of main-stream models would be 64K or larger.

However, the usage of GQA in models like mistral and LLama-3 cuts the min page siz to 16K. So update the verification function accordingly.

Verification:
Tested e2e with pd-disaggreation vllm, the allocator-size of 16k works.