### PR TITLE
rdma connection support async interface

### DIFF
--- a/infinistore/example/client.py
+++ b/infinistore/example/client.py
@@ -76,15 +76,15 @@ if __name__ == "__main__":
     rdma_conn.connect()
     m = [
         ("cpu", "cuda:0"),
-        ("cuda:0", "cuda:1"),
-        ("cuda:0", "cpu"),
-        ("cpu", "cpu"),
+        #    ("cuda:0", "cuda:1"),
+        #    ("cuda:0", "cpu"),
+        #    ("cpu", "cpu"),
     ]
     for src, dst in m:
         print(f"rdma connection: {src} -> {dst}")
         run(rdma_conn, src, dst)
 
-    config.connection_type = infinistore.TYPE_LOCAL_GPU
-    local_conn = InfinityConnection(config)
-    local_conn.connect()
-    run(local_conn)
+    # config.connection_type = infinistore.TYPE_LOCAL_GPU
+    # local_conn = InfinityConnection(config)
+    # local_conn.connect()
+    # run(local_conn)

--- a/infinistore/example/client.py
+++ b/infinistore/example/client.py
@@ -76,15 +76,15 @@ if __name__ == "__main__":
     rdma_conn.connect()
     m = [
         ("cpu", "cuda:0"),
-        #    ("cuda:0", "cuda:1"),
-        #    ("cuda:0", "cpu"),
-        #    ("cpu", "cpu"),
+        ("cuda:0", "cuda:1"),
+        ("cuda:0", "cpu"),
+        ("cpu", "cpu"),
     ]
     for src, dst in m:
         print(f"rdma connection: {src} -> {dst}")
         run(rdma_conn, src, dst)
 
-    # config.connection_type = infinistore.TYPE_LOCAL_GPU
-    # local_conn = InfinityConnection(config)
-    # local_conn.connect()
-    # run(local_conn)
+    config.connection_type = infinistore.TYPE_LOCAL_GPU
+    local_conn = InfinityConnection(config)
+    local_conn.connect()
+    run(local_conn)

--- a/infinistore/example/client_async.py
+++ b/infinistore/example/client_async.py
@@ -1,0 +1,55 @@
+import uvloop
+import infinistore
+import uuid
+import torch
+
+# import asyncio
+
+
+def generate_uuid():
+    return str(uuid.uuid4())
+
+
+config = infinistore.ClientConfig(
+    host_addr="127.0.0.1",
+    service_port=12345,
+    log_level="info",
+    connection_type=infinistore.TYPE_RDMA,
+    ib_port=1,
+    link_type=infinistore.LINK_ETHERNET,
+    dev_name="mlx5_0",
+)
+
+print("Connecting to Infinistore server")
+rdma_conn = infinistore.InfinityConnection(config)
+
+# FIXME: This is a blocking call, should be async
+rdma_conn.connect()
+
+src_tensor = torch.tensor([i for i in range(4096)], device="cpu", dtype=torch.float32)
+
+dst_tensor = torch.zeros(4096, device="cpu", dtype=torch.float32)
+
+rdma_conn.register_mr(src_tensor)
+rdma_conn.register_mr(dst_tensor)
+
+
+async def main():
+    keys = [generate_uuid() for _ in range(3)]
+    remote_addr = await rdma_conn.allocate_rdma_async(keys, 1024 * 4)
+    print(f"remote addrs is {remote_addr}")
+
+    await rdma_conn.rdma_write_cache_async(src_tensor, [0, 1024], 1024, remote_addr[:2])
+    await rdma_conn.rdma_write_cache_async(src_tensor, [2048], 1024, remote_addr[2:])
+
+    # await asyncio.gather(rdma_conn.rdma_write_cache_async(src_tensor, [0, 1024], 1024, remote_addr[:2]),
+    #                rdma_conn.rdma_write_cache_async(src_tensor, [2048], 1024, remote_addr[2:]))
+
+    await rdma_conn.read_cache_async(
+        dst_tensor, [(keys[0], 0), (keys[1], 1024), (keys[2], 2048)], 1024
+    )
+
+    assert torch.equal(src_tensor[0:3072].cpu(), dst_tensor[0:3072].cpu())
+
+
+uvloop.run(main())

--- a/infinistore/lib.py
+++ b/infinistore/lib.py
@@ -435,13 +435,6 @@ class InfinityConnection:
 
         # each offset should multiply by the element size
         offsets_in_bytes = [offset * element_size for offset in offsets]
-        # ret = _infinistore.w_rdma(
-        #     self.conn,
-        #     offsets_in_bytes,
-        #     page_size * element_size,
-        #     remote_blocks,
-        #     ptr,
-        # )
 
         ret = self.conn.w_rdma(
             offsets_in_bytes,
@@ -509,15 +502,6 @@ class InfinityConnection:
         if len(cuda_visible_devices) > 0:
             device_id = int(cuda_visible_devices.split(",")[cache.device.index])
         if self.local_connected:
-            # ret = _infinistore.rw_local(
-            #     self.conn,
-            #     self.OP_R,
-            #     blocks_in_bytes,
-            #     page_size * element_size,
-            #     ptr,
-            #     device_id,
-            # )
-
             ret = self.conn.rw_local(
                 self.OP_R,
                 blocks_in_bytes,
@@ -528,13 +512,6 @@ class InfinityConnection:
             if ret < 0:
                 raise Exception(f"Failed to read to infinistore, ret = {ret}")
         elif self.rdma_connected:
-            # ret = _infinistore.r_rdma(
-            #     self.conn,
-            #     blocks_in_bytes,
-            #     page_size * element_size,
-            #     ptr,
-            # )
-
             ret = self.conn.r_rdma(
                 blocks_in_bytes,
                 page_size * element_size,
@@ -560,8 +537,6 @@ class InfinityConnection:
             n = 0
             timeout = 1  # 1 second timeout
             while True:
-                # ret = _infinistore.sync_local(self.conn)
-
                 ret = self.conn.sync_local()
                 if ret < 0:
                     raise Exception(f"Failed to sync to infinistore, ret = {ret}")
@@ -602,7 +577,6 @@ class InfinityConnection:
         Raises:
             Exception: If there is an error checking the key's existence.
         """
-        # ret = _infinistore.check_exist(self.conn, key)
         ret = self.conn.check_exist(key)
         if ret < 0:
             raise Exception("Failed to check if this key exists")
@@ -621,7 +595,6 @@ class InfinityConnection:
         Raises:
             Exception: If no match is found (i.e., if the return value is negative).
         """
-        # ret = _infinistore.get_match_last_index(self.conn, keys)
         ret = self.conn.get_match_last_index(keys)
         if ret < 0:
             raise Exception("can't find a match")
@@ -645,7 +618,6 @@ class InfinityConnection:
         element_size = cache.element_size()
         if not self.rdma_connected:
             raise Exception("this function is only valid for connected rdma")
-        # ret = _infinistore.register_mr(self.conn, ptr, cache.numel() * element_size)
 
         ret = self.conn.register_mr(ptr, cache.numel() * element_size)
         if ret < 0:
@@ -663,8 +635,6 @@ class InfinityConnection:
             # _callback is invoked by the C++ code in cq_thread,
             # so we need to call_soon_threadsafe
             loop.call_soon_threadsafe(future.set_result, remote_addrs)
-
-        # _infinistore.allocate_rdma_async(self.conn, keys, page_size_in_bytes, _callback)
 
         self.conn.allocate_rdma_async(keys, page_size_in_bytes, _callback)
 
@@ -689,7 +659,6 @@ class InfinityConnection:
         if not self.rdma_connected:
             raise Exception("this function is only valid for connected rdma")
 
-        # ret = _infinistore.allocate_rdma(self.conn, keys, page_size_in_bytes)
         ret = self.conn.allocate_rdma(keys, page_size_in_bytes)
         if len(ret) == 0:
             raise Exception("allocate memory failed")

--- a/infinistore/server.py
+++ b/infinistore/server.py
@@ -82,8 +82,11 @@ async def selftest(number: int):
         dst_tensor, [(keys[0], 0), (keys[1], 1024), (keys[2], 2048)], 1024
     )
 
-    assert torch.equal(src_tensor[0:3072].cpu(), dst_tensor[0:3072].cpu())
+    # put assert into asyncio.to_thread
 
+    assert await asyncio.to_thread(torch.equal, src_tensor[0:3072], dst_tensor[0:3072])
+
+    # assert torch.equal(,
     rdma_conn = None
     return {"status": "ok"}
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -Wall -O3 -g
+CXXFLAGS = -std=c++17 -Wall -O2 -g
 
 INCLUDES = -I/usr/local/cuda/include
 LDFLAGS = -L/usr/local/cuda/lib64

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -Wall -O3 -g
+CXXFLAGS = -std=c++17 -Wall -O0 -g
 
 INCLUDES = -I/usr/local/cuda/include
 LDFLAGS = -L/usr/local/cuda/lib64

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,5 +1,5 @@
 CXX = g++
-CXXFLAGS = -std=c++17 -Wall -O0 -g
+CXXFLAGS = -std=c++17 -Wall -O3 -g
 
 INCLUDES = -I/usr/local/cuda/include
 LDFLAGS = -L/usr/local/cuda/lib64

--- a/src/Makefile
+++ b/src/Makefile
@@ -2,8 +2,8 @@ CXX = g++
 CXXFLAGS = -std=c++17 -Wall -O2 -g
 
 INCLUDES = -I/usr/local/cuda/include
-LDFLAGS = -L/usr/local/cuda/lib64
-LIBS = -lcudart -luv -libverbs -lfmt
+LDFLAGS = -L/usr/local/cuda/lib64 -rdynamic
+LIBS = -lcudart -luv -libverbs -lfmt -lboost_stacktrace_basic -ldl
 PYTHON=python3
 PYBIND11_INCLUDES = $(shell $(PYTHON) -m pybind11 --includes)
 PYTHON_EXTENSION_SUFFIX = $(shell $(PYTHON)-config --extension-suffix)
@@ -17,9 +17,9 @@ all:$(PYBIND_TARGET)
 
 manylinux: PYTHON ?= python3.11
 manylinux: CXXFLAGS = -std=c++17 -g -O3 -Wall
-manylinux: LIBS = -lcudart -luv -libverbs
+manylinux: LIBS = -lcudart -luv -libverbs -lfmt -lboost_stacktrace_basic -ldl
 manylinux: INCLUDES += -I/usr/local/include -I$(shell $(PYTHON) -c "import site; print(site.getsitepackages()[0])")/triton/backends/nvidia/include/
-manylinux: LDFLAGS += -L$(shell $(PYTHON) -c "import site; print(site.getsitepackages()[0])")/nvidia/cuda_runtime/lib/
+manylinux: LDFLAGS += -L$(shell $(PYTHON) -c "import site; print(site.getsitepackages()[0])")/nvidia/cuda_runtime/lib/ -rdynamic
 manylinux: PYBIND11_INCLUDES = $(shell $(PYTHON) -m pybind11 --includes)
 manylinux: PYTHON_EXTENSION_SUFFIX = $(shell $(PYTHON)-config --extension-suffix)
 manylinux: PYBIND_TARGET = _infinistore$(PYTHON_EXTENSION_SUFFIX)

--- a/src/infinistore.cpp
+++ b/src/infinistore.cpp
@@ -45,7 +45,6 @@ bool extend_in_flight = false;
 // indicate the number of cudaIpcOpenMemHandle
 std::atomic<unsigned int> opened_ipc{0};
 
-
 enum CUDA_TASK_TYPE {
     CUDA_READ,
     CUDA_WRITE,
@@ -162,7 +161,9 @@ Client::~Client() {
     for (int i = 0; i < MAX_RECV_WR; i++) {
         if (recv_buffer_[i]) {
             free(recv_buffer_[i]);
+            recv_buffer_[i] = NULL;
             ibv_dereg_mr(recv_mr_[i]);
+            recv_mr_[i] = NULL;
         }
     }
 

--- a/src/infinistore.h
+++ b/src/infinistore.h
@@ -29,7 +29,7 @@ extern std::atomic<unsigned int> opened_ipc;
 // PTR is shared by kv_map and inflight_rdma_kv_map
 class PTR : public IntrusivePtrTarget {
    public:
-    void *ptr;
+    void *ptr = nullptr;
     size_t size;
     int pool_idx;
     bool committed;

--- a/src/libinfinistore.h
+++ b/src/libinfinistore.h
@@ -9,7 +9,7 @@
 #include <unistd.h>
 
 #include <atomic>
-#include <boost/lockfree/queue.hpp>
+#include <boost/lockfree/spsc_queue.hpp>
 #include <deque>
 #include <future>
 #include <map>
@@ -57,7 +57,7 @@ class Connection : public std::enable_shared_from_this<Connection> {
     This is MAX_RECV_WR not MAX_SEND_WR,
     because server also has the same number of buffers
     */
-    boost::lockfree::queue<SendBuffer *> send_buffers_{MAX_RECV_WR};
+    boost::lockfree::spsc_queue<SendBuffer *> send_buffers_{MAX_RECV_WR};
 
     // this recv buffer is used in
     // 1. allocate rdma

--- a/src/libinfinistore.h
+++ b/src/libinfinistore.h
@@ -87,6 +87,12 @@ struct Connection {
 
 typedef struct Connection connection_t;
 
+struct rdma_read_commit_info {
+    // call back function.
+    std::function<void()> callback;
+    rdma_read_commit_info(std::function<void()> callback) : callback(callback) {}
+};
+
 struct rdma_write_commit_info {
     // call back function.
     std::function<void()> callback;
@@ -107,6 +113,8 @@ int rw_local(connection_t *conn, char op, const std::vector<block_t> &blocks, in
 int sync_local(connection_t *conn);
 int setup_rdma(connection_t *conn, client_config_t config);
 int r_rdma(connection_t *conn, std::vector<block_t> &blocks, int block_size, void *base_ptr);
+int r_rdma_async(connection_t *conn, std::vector<block_t> &blocks, int block_size, void *base_ptr,
+                 std::function<void()> callback);
 int w_rdma(connection_t *conn, unsigned long *p_offsets, size_t offsets_len, int block_size,
            remote_block_t *p_remote_blocks, size_t remote_blocks_len, void *base_ptr);
 int w_rdma_async(connection_t *conn, unsigned long *p_offsets, size_t offsets_len, int block_size,

--- a/src/libinfinistore.h
+++ b/src/libinfinistore.h
@@ -8,10 +8,12 @@
 #include <time.h>
 #include <unistd.h>
 
+#include <atomic>
 #include <boost/lockfree/queue.hpp>
 #include <deque>
 #include <future>
 #include <map>
+#include <stdexcept>
 
 #include "config.h"
 #include "log.h"
@@ -29,63 +31,95 @@ struct SendBuffer {
     ~SendBuffer();
 };
 
-struct Connection {
+class Connection : public std::enable_shared_from_this<Connection> {
     // tcp socket
-    int sock = 0;
+    int sock_ = 0;
 
     // rdma connections
-    struct ibv_context *ib_ctx = NULL;
-    struct ibv_pd *pd = NULL;
-    struct ibv_cq *cq = NULL;
-    struct ibv_qp *qp = NULL;
-    int gidx = -1;
-    int lid = -1;
-    uint8_t ib_port = -1;
+    struct ibv_context *ib_ctx_ = NULL;
+    struct ibv_pd *pd_ = NULL;
+    struct ibv_cq *cq_ = NULL;
+    struct ibv_qp *qp_ = NULL;
+    int gidx_ = -1;
+    int lid_ = -1;
+    uint8_t ib_port_ = -1;
 
     // local active_mtu attr, after exchanging with remote, we will use the min of the two for
     // path.mtu
-    ibv_mtu active_mtu;
+    ibv_mtu active_mtu_;
 
-    rdma_conn_info_t local_info;
-    rdma_conn_info_t remote_info;
+    rdma_conn_info_t local_info_;
+    rdma_conn_info_t remote_info_;
 
-    std::unordered_map<uintptr_t, struct ibv_mr *> local_mr;
+    std::unordered_map<uintptr_t, struct ibv_mr *> local_mr_;
 
     /*
     This is MAX_RECV_WR not MAX_SEND_WR,
     because server also has the same number of buffers
     */
-    boost::lockfree::queue<SendBuffer *> send_buffers{MAX_RECV_WR};
+    boost::lockfree::queue<SendBuffer *> send_buffers_{MAX_RECV_WR};
 
     // this recv buffer is used in
     // 1. allocate rdma
     // 2. recv IMM data, althougth IMM DATA is not put into recv_buffer,
     // but for compatibility, we still use a zero-length recv_buffer.
-    void *recv_buffer = NULL;
-    struct ibv_mr *recv_mr = NULL;
+    void *recv_buffer_ = NULL;
+    struct ibv_mr *recv_mr_ = NULL;
 
-    struct ibv_comp_channel *comp_channel = NULL;
-    std::future<void> cq_future;  // cq thread
-    std::atomic<int> rdma_inflight_count{0};
+    struct ibv_comp_channel *comp_channel_ = NULL;
+    std::future<void> cq_future_;  // cq thread
+    std::atomic<int> rdma_inflight_count_{0};
 
-    std::atomic<bool> stop{false};
+    std::atomic<bool> stop_{false};
     // protect rdma_inflight_count
-    std::mutex mutex;
-    std::condition_variable cv;
+    std::mutex mutex_;
+    std::condition_variable cv_;
 
     // protect ibv_post_send, outstanding_rdma_writes_queue
-    std::mutex rdma_post_send_mutex;
-    std::atomic<int> outstanding_rdma_writes{0};
-    std::deque<std::pair<struct ibv_send_wr *, struct ibv_sge *>> outstanding_rdma_writes_queue;
+    std::mutex rdma_post_send_mutex_;
+    std::atomic<int> outstanding_rdma_writes_{0};
+    std::deque<std::pair<struct ibv_send_wr *, struct ibv_sge *>> outstanding_rdma_writes_queue_;
 
+   public:
     Connection() = default;
 
     Connection(const Connection &) = delete;
     // destory the connection
     ~Connection();
-};
+    int init_connection(client_config_t config);
+    // async rw local cpu memory, even rw_local returns, it is not guaranteed that
+    // the operation is completed until sync_local is recved.
+    int rw_local(char op, const std::vector<block_t> &blocks, int block_size, void *ptr,
+                 int device_id);
+    int sync_local();
+    int setup_rdma(client_config_t config);
+    int r_rdma(std::vector<block_t> &blocks, int block_size, void *base_ptr);
+    int r_rdma_async(std::vector<block_t> &blocks, int block_size, void *base_ptr,
+                     std::function<void()> callback);
+    int w_rdma(unsigned long *p_offsets, size_t offsets_len, int block_size,
+               remote_block_t *p_remote_blocks, size_t remote_blocks_len, void *base_ptr);
+    int w_rdma_async(unsigned long *p_offsets, size_t offsets_len, int block_size,
+                     remote_block_t *p_remote_blocks, size_t remote_blocks_len, void *base_ptr,
+                     std::function<void()> callback);
+    int sync_rdma();
+    std::vector<remote_block_t> *allocate_rdma(std::vector<std::string> &keys, int block_size);
+    int allocate_rdma_async(std::vector<std::string> &keys, int block_size,
+                            std::function<void(std::vector<remote_block_t> *)> callback);
+    int check_exist(std::string key);
+    int get_match_last_index(std::vector<std::string>);
+    int register_mr(void *base_ptr, size_t ptr_region_size);
 
-typedef struct Connection connection_t;
+    int modify_qp_to_init();
+    int modify_qp_to_rts();
+    int modify_qp_to_rtr();
+    int exchange_conn_info();
+    int init_rdma_resources(client_config_t config);
+
+    void cq_handler();
+    // TODO: refactor to c++ style
+    SendBuffer *get_send_buffer();
+    void release_send_buffer(SendBuffer *buffer);
+};
 
 struct rdma_read_commit_info {
     // call back function.
@@ -104,33 +138,5 @@ struct rdma_write_commit_info {
         remote_addrs.reserve(n);
     }
 };
-
-int init_connection(connection_t *conn, client_config_t config);
-// async rw local cpu memory, even rw_local returns, it is not guaranteed that
-// the operation is completed until sync_local is recved.
-int rw_local(connection_t *conn, char op, const std::vector<block_t> &blocks, int block_size,
-             void *ptr, int device_id);
-int sync_local(connection_t *conn);
-int setup_rdma(connection_t *conn, client_config_t config);
-int r_rdma(connection_t *conn, std::vector<block_t> &blocks, int block_size, void *base_ptr);
-int r_rdma_async(connection_t *conn, std::vector<block_t> &blocks, int block_size, void *base_ptr,
-                 std::function<void()> callback);
-int w_rdma(connection_t *conn, unsigned long *p_offsets, size_t offsets_len, int block_size,
-           remote_block_t *p_remote_blocks, size_t remote_blocks_len, void *base_ptr);
-int w_rdma_async(connection_t *conn, unsigned long *p_offsets, size_t offsets_len, int block_size,
-                 remote_block_t *p_remote_blocks, size_t remote_blocks_len, void *base_ptr,
-                 std::function<void()> callback);
-int sync_rdma(connection_t *conn);
-std::vector<remote_block_t> *allocate_rdma(connection_t *conn, std::vector<std::string> &keys,
-                                           int block_size);
-int allocate_rdma_async(connection_t *conn, std::vector<std::string> &keys, int block_size,
-                        std::function<void(std::vector<remote_block_t> *)> callback);
-int check_exist(connection_t *conn, std::string key);
-int get_match_last_index(connection_t *conn, std::vector<std::string>);
-int register_mr(connection_t *conn, void *base_ptr, size_t ptr_region_size);
-
-// TODO: refactor to c++ style
-SendBuffer *get_send_buffer(connection_t *conn);
-void release_send_buffer(connection_t *conn, SendBuffer *buffer);
 
 #endif  // LIBINFINISTORE_H

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -49,6 +49,9 @@ PYBIND11_MODULE(_infinistore, m) {
     py::class_<Connection, std::shared_ptr<Connection>>(m, "Connection")
         .def(py::init<>())
         .def(
+            "__del__", [](Connection &self) { self.~Connection(); },
+            py::call_guard<py::gil_scoped_release>())
+        .def(
             "rw_local",
             [](Connection &self, char op,
                const std::vector<std::tuple<std::string, unsigned long>> &blocks, int block_size,

--- a/src/pybind.cpp
+++ b/src/pybind.cpp
@@ -48,7 +48,6 @@ PYBIND11_MODULE(_infinistore, m) {
 
     py::class_<Connection, std::shared_ptr<Connection>>(m, "Connection")
         .def(py::init<>())
-        .def("init_connection", &Connection::init_connection, "Initialize a connection")
         .def(
             "rw_local",
             [](Connection &self, char op,
@@ -159,7 +158,10 @@ PYBIND11_MODULE(_infinistore, m) {
             "Allocate remote memory asynchronously")
 
         .def("sync_local", &Connection::sync_local, "sync the cuda stream")
-        .def("setup_rdma", &Connection::setup_rdma, "setup rdma connection")
+        .def("init_connection", &Connection::init_connection,
+             py::call_guard<py::gil_scoped_release>(), "init connection")
+        .def("setup_rdma", &Connection::setup_rdma, py::call_guard<py::gil_scoped_release>(),
+             "setup rdma connection")
         .def("sync_rdma", &Connection::sync_rdma, "sync the remote server")
         .def("check_exist", &Connection::check_exist, "check if the key exists in the store")
         .def("get_match_last_index", &Connection::get_match_last_index,
@@ -170,7 +172,7 @@ PYBIND11_MODULE(_infinistore, m) {
             [](Connection &self, uintptr_t ptr, size_t ptr_region_size) {
                 return self.register_mr((void *)ptr, ptr_region_size);
             },
-            "register memory region");
+            py::call_guard<py::gil_scoped_release>(), "register memory region");
 
     // server side
     py::class_<server_config_t>(m, "ServerConfig")

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -9,6 +9,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include <boost/stacktrace.hpp>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
@@ -109,6 +110,15 @@ void compare_ipc_handle(cudaIpcMemHandle_t ipc_handle1, cudaIpcMemHandle_t ipc_h
             return;
         }
     }
+}
+
+void signal_handler(int signum) {
+    INFO("Interrupt signal ({}) received.", signum);
+    boost::stacktrace::stacktrace st;
+    std::ostringstream oss;
+    oss << st;
+    ERROR("Stacktrace:\n{}", oss.str());
+    exit(1);
 }
 
 template <typename T>

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,6 +26,7 @@ int recv_exact(int socket, void *buffer, size_t length);
 void print_ipc_handle(cudaIpcMemHandle_t ipc_handle);
 void compare_ipc_handle(cudaIpcMemHandle_t ipc_handle1, cudaIpcMemHandle_t ipc_handle2);
 void print_rdma_conn_info(rdma_conn_info_t *info, bool is_remote);
+void signal_handler(int signum);
 
 // print vector is super slow. Use it only for debugging
 template <typename T>


### PR DESCRIPTION
async API is critical for these scenarios, so we need a new set of async API

1.  vllm could use async api to *download kvcache before engine*
2.  infinistore cluster could connect to each other to *migrate* data
 
## features
1. add new interface:
   a. connect_async
   b. allocate_rdma_async
   c. write_rdma_cache_async
   d. read_cache_async
3. add new http api to do selftest
   ```
   curl -XPOST http://127.0.0.1:18088/selftest
   ``` 
4. Refactor libinfinistore.cpp to fix some rare bugs. (deadlock when using async API)